### PR TITLE
Allow tool upgrades from branches

### DIFF
--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -78,10 +78,10 @@ doUpgradeToolsFromCommit(){
 }
 
 doUpgradeToolsFromBranch(){
-  atlasstLatestVersion=`curl -s "https://raw.githubusercontent.com/${atlasstGithubRepo}/${atlasstChannel}/.version"`
+  atlasstLatestVersion="${atlasstVersion}-${atlasstChannel}"
   atlasstLatestCommit=`curl -s "https://api.github.com/repos/${atlasstGithubRepo}/git/refs/heads/${atlasstChannel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
 
-  if [[ "$atlasstLatestVersion" == "404: Not Found" ]]; then
+  if [[ -z $atlasstLatestCommit ]]; then
     echo "Channel '${atlasstChannel}' does not exist"
     echo
     echo "Available channels:"


### PR DESCRIPTION
## Issue
Meant to resolve #14
Allow a user to successfully upgrade atlas-server-tools from a non-master branch.

## Solution
Check if the latest commit at the given repo / branch was found instead of looking for the `.version` file that was removed in d0f991a03fed666d37acf90d7f9ce8962aa7a915.  Also, just use the current version with an appended branch name for the `atlasstLatestVersion` so that it always allows the upgrade.

## Thoughts
Honestly, I don't really like the way I have this working, but not sure how much effort it is worth putting into it either.  A possible fix might be to use the `atlasmanager` script on the fork / branch and use `sed` to obtain the `atlasstVersion` value, but that seems like a lot to download and filter just to check the version.  Still, definitely not married to this half-assed "get-it-working" change.