### PR TITLE
Backup non-seamless Game / GUS ini files

### DIFF
--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3177,8 +3177,8 @@ doBackup(){
   fi
 
 
-   echo -ne "${NORMAL} Copying Game.ini "
-
+  echo -ne "${NORMAL} Copying Game.ini "
+  [ ! -d $savedcfgdir ] && savedcfgdir="${saverootdir}/Config/LinuxServer"
   cp -p "${savedcfgdir}/Game.ini" "${backupdir}/Game.ini"
   if [ ! -s "${backupdir}/Game.ini" ]; then
     sleep 2

--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3164,6 +3164,9 @@ doBackup(){
   fi
 
   # ATLAS server uses Lock-Truncate-Write-Unlock
+
+  [ ! -d $savedcfgdir ] && savedcfgdir="${saverootdir}/Config/LinuxServer"
+
   echo -ne "${NORMAL} Copying GameUserSettings.ini "
   cp -p "${savedcfgdir}/GameUserSettings.ini" "${backupdir}/GameUserSettings.ini"
   if [ ! -s "${backupdir}/GameUserSettings.ini" ]; then
@@ -3178,7 +3181,6 @@ doBackup(){
 
 
   echo -ne "${NORMAL} Copying Game.ini "
-  [ ! -d $savedcfgdir ] && savedcfgdir="${saverootdir}/Config/LinuxServer"
   cp -p "${savedcfgdir}/Game.ini" "${backupdir}/Game.ini"
   if [ ! -s "${backupdir}/Game.ini" ]; then
     sleep 2


### PR DESCRIPTION
## Issue
Backup fails to copy the `Game.ini` and `GameUserSettings.ini` files (and this back them up) for seamless servers because we're looking in a folder that does not exist.

## Solution
When hosting a non-seamless server, the ini files are saved in a more central location: the same place where they are saved for ARK servers.  However, to ensure that we do not conflict with seamless servers, only make the switch if the original folder does not exist.

## Thoughts
I do not run a seamless server so it's a little hard to tell how compatible this is.