### PR TITLE
Backup non-seamless data files

### DIFF
--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3087,19 +3087,19 @@ doBackup(){
   for f in "${savedir}/"*.arktribe; do
     cp -p "${f}" "${backupdir}/${f##*/}"
     
-    if [ ! -f "${backupdir}/${f}" ]; then
+    if [ ! -f "${backupdir}/${f##*/}" ]; then
       sleep 2
       cp -p "${f}" "${backupdir}/${f##*/}"
     fi
 
-    if [ ! -f "${backupdir}/${f}" ]; then
+    if [ ! -f "${backupdir}/${f##*/}" ]; then
       [[ -z $failedTribes ]] && failedTribes="${NORMAL}  Failed to backup tribes:"
       failedTribes="${failedTribes}\n    ${f}"
     fi
   done
   if [[ ! -z $failedTribes ]]; then
     echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
-    echo -ne $failedTribes
+    echo -e $failedTribes
   else
     echo -e "${NORMAL}\e[68G[   ${GREEN}OK${NORMAL}   ]"
   fi
@@ -3110,19 +3110,19 @@ doBackup(){
   for f in "${savedir}/"*.playerentities; do
     cp -p "${f}" "${backupdir}/${f##*/}"
     
-    if [ ! -f "${backupdir}/${f}" ]; then
+    if [ ! -f "${backupdir}/${f##*/}" ]; then
       sleep 2
       cp -p "${f}" "${backupdir}/${f##*/}"
     fi
 
-    if [ ! -f "${backupdir}/${f}" ]; then
+    if [ ! -f "${backupdir}/${f##*/}" ]; then
       [[ -z $failedEntities ]] && failedEntities="${NORMAL}  Failed to backup entities:"
       failedEntities="${failedEntities}\n    ${f}"
     fi
   done
   if [[ ! -z $failedEntities ]]; then
     echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
-    echo -ne $failedEntities
+    echo -e $failedEntities
   else
     echo -e "${NORMAL}\e[68G[   ${GREEN}OK${NORMAL}   ]"
   fi
@@ -3133,19 +3133,19 @@ doBackup(){
   for f in "${savedir}/"*.arkprofile; do
     cp -p "${f}" "${backupdir}/${f##*/}"
     
-    if [ ! -f "${backupdir}/${f}" ]; then
+    if [ ! -f "${backupdir}/${f##*/}" ]; then
       sleep 2
       cp -p "${f}" "${backupdir}/${f##*/}"
     fi
 
-    if [ ! -f "${backupdir}/${f}" ]; then
+    if [ ! -f "${backupdir}/${f##*/}" ]; then
       [[ -z $failedProfiles ]] && failedProfiles="${NORMAL}  Failed to backup profiles:"
       failedProfiles="${failedProfiles}\n    ${f}"
     fi
   done
   if [[ ! -z $failedProfiles ]]; then
     echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
-    echo -ne $failedProfiles
+    echo -e $failedProfiles
   else
     echo -e "${NORMAL}\e[68G[   ${GREEN}OK${NORMAL}   ]"
   fi

--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3081,6 +3081,27 @@ doBackup(){
     done
   fi
 
+  # Copy tribe files
+  echo -ne "${NORMAL} Copying tribe files "
+  failedTribes=
+  for f in "${savedir}/"*.arktribe; do
+    cp -p "${f}" "${backupdir}/${f##*/}"
+    
+    if [ ! -f "${backupdir}/${f}" ]; then
+      sleep 2
+      cp -p "${f}" "${backupdir}/${f##*/}"
+    fi
+
+    if [ ! -f "${backupdir}/${f}" ]; then
+      [[ -z $failedTribes ]] && failedTribes="${NORMAL}  Failed to backup tribes:"
+      failedTribes="${failedTribes}\n    ${f}"
+    fi
+  done
+  if [[ ! -z $failedTribes ]]; then
+    echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
+    echo -ne $failedTribes
+  fi
+
   # Copy atlasmanager.cfg with default instance
   if [ "$instance" == "$defaultinstance" ]; then
     echo -ne "${NORMAL} Copying atlasmanager.cfg "

--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3102,6 +3102,28 @@ doBackup(){
     echo -ne $failedTribes
   fi
 
+  # Copy player entities files
+  echo -ne "${NORMAL} Copying entities files "
+  failedEntities=
+  for f in "${savedir}/"*.playerentities; do
+    cp -p "${f}" "${backupdir}/${f##*/}"
+    
+    if [ ! -f "${backupdir}/${f}" ]; then
+      sleep 2
+      cp -p "${f}" "${backupdir}/${f##*/}"
+    fi
+
+    if [ ! -f "${backupdir}/${f}" ]; then
+      [[ -z $failedEntities ]] && failedEntities="${NORMAL}  Failed to backup tribes:"
+      failedEntities="${failedEntities}\n    ${f}"
+    fi
+  done
+  if [[ ! -z $failedEntities ]]; then
+    echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
+    echo -ne $failedEntities
+  fi
+
+
   # Copy atlasmanager.cfg with default instance
   if [ "$instance" == "$defaultinstance" ]; then
     echo -ne "${NORMAL} Copying atlasmanager.cfg "

--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3123,6 +3123,26 @@ doBackup(){
     echo -ne $failedEntities
   fi
 
+# Copy arkprofile files
+  echo -ne "${NORMAL} Copying arkprofile files "
+  failedProfiles=
+  for f in "${savedir}/"*.arkprofile; do
+    cp -p "${f}" "${backupdir}/${f##*/}"
+    
+    if [ ! -f "${backupdir}/${f}" ]; then
+      sleep 2
+      cp -p "${f}" "${backupdir}/${f##*/}"
+    fi
+
+    if [ ! -f "${backupdir}/${f}" ]; then
+      [[ -z $failedProfiles ]] && failedProfiles="${NORMAL}  Failed to backup profiles:"
+      failedProfiles="${failedProfiles}\n    ${f}"
+    fi
+  done
+  if [[ ! -z $failedProfiles ]]; then
+    echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
+    echo -ne $failedProfiles
+  fi
 
   # Copy atlasmanager.cfg with default instance
   if [ "$instance" == "$defaultinstance" ]; then

--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3114,7 +3114,7 @@ doBackup(){
     fi
 
     if [ ! -f "${backupdir}/${f}" ]; then
-      [[ -z $failedEntities ]] && failedEntities="${NORMAL}  Failed to backup tribes:"
+      [[ -z $failedEntities ]] && failedEntities="${NORMAL}  Failed to backup entities:"
       failedEntities="${failedEntities}\n    ${f}"
     fi
   done

--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3100,6 +3100,8 @@ doBackup(){
   if [[ ! -z $failedTribes ]]; then
     echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
     echo -ne $failedTribes
+  else
+    echo -e "${NORMAL}\e[68G[   ${GREEN}OK${NORMAL}   ]"
   fi
 
   # Copy player entities files
@@ -3121,6 +3123,8 @@ doBackup(){
   if [[ ! -z $failedEntities ]]; then
     echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
     echo -ne $failedEntities
+  else
+    echo -e "${NORMAL}\e[68G[   ${GREEN}OK${NORMAL}   ]"
   fi
 
 # Copy arkprofile files
@@ -3142,6 +3146,8 @@ doBackup(){
   if [[ ! -z $failedProfiles ]]; then
     echo -e "${NORMAL}\e[68G[  ${YELLOW}WARN${NORMAL}  ]"
     echo -ne $failedProfiles
+  else
+    echo -e "${NORMAL}\e[68G[   ${GREEN}OK${NORMAL}   ]"
   fi
 
   # Copy atlasmanager.cfg with default instance


### PR DESCRIPTION
## Issue
Non-seamless servers do not use redis to store information about players, ships, or tribes.  Instead they are stored in `.arktribe`, `.arkprofile`, and `.playerentities` files.  However, these files are not being backed up by atlas-server-tools.

## Solution
Add loops to copy each file into the backup folder and log any that failed, but do not abort the backup of any others.

## Thoughts
I'm not in love with the loops, but I wanted to make sure we weren't competing with ATLAS writes like some of the other files.  It runs fairly quickly in small servers.

Perhaps a setting should be introduced to the instance configuration files such as `isSeamless` which defaults to true if missing (or if `serverMap` isn't Ocean), and only does some of these backups I've opened PRs for when it's false.